### PR TITLE
Add null check for customer password

### DIFF
--- a/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -147,7 +147,8 @@ class LoginRoute extends AbstractLoginRoute
             return $customer;
         }
 
-        if (!password_verify($password, $customer->getPassword())) {
+        if (null === $customer->getPassword()
+            || !password_verify($password, $customer->getPassword())) {
             throw new BadCredentialsException();
         }
 


### PR DESCRIPTION
The customer password is null or string. The password_verify requires a string as second parameter so errors can occur while checking the customer password. If it is null there is an Uncaught PHP Exception possible.

Signed-off-by: Jelle Deneweth <jelle.deneweth@gmail.com>