### PR TITLE
Core issue when having no customerId

### DIFF
--- a/Checkout/Customer/Subscriber/CustomerMetaFieldSubscriber.php
+++ b/Checkout/Customer/Subscriber/CustomerMetaFieldSubscriber.php
@@ -72,7 +72,7 @@ class CustomerMetaFieldSubscriber implements EventSubscriberInterface
         }
 
         $customerIds = $this->connection->fetchFirstColumn(
-            'SELECT DISTINCT LOWER(HEX(customer_id)) FROM `order_customer` WHERE order_id IN (:ids) AND order_version_id = :version',
+            'SELECT DISTINCT LOWER(HEX(customer_id)) FROM `order_customer` WHERE order_id IN (:ids) AND order_version_id = :version AND customer_id IS NOT NULL',
             ['ids' => Uuid::fromHexToBytesList($orderIds), 'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)],
             ['ids' => Connection::PARAM_STR_ARRAY]
         );


### PR DESCRIPTION
Most marketplaces connectors integrate and create orders in SW without customerId = NULL the $customerId = then null instead of empty.
this fix resolve the issue that orders can't be changed to Done/completed.