### PR TITLE
Set boolean field to NULL if value is null in Export

### DIFF
--- a/Content/ImportExport/DataAbstractionLayer/Serializer/Field/FieldSerializer.php
+++ b/Content/ImportExport/DataAbstractionLayer/Serializer/Field/FieldSerializer.php
@@ -71,7 +71,7 @@ class FieldSerializer extends AbstractFieldSerializer
 
             yield $key => (string) $value;
         } elseif ($field instanceof BoolField) {
-            yield $key => $value === true ? '1' : '0';
+            yield $key => $value === true ? '1' : ($value === null ? null : '0');
         } elseif ($field instanceof JsonField) {
             yield $key => $value === null ? null : json_encode($value);
         } else {


### PR DESCRIPTION
Product variants with inherited values (NULL) cannot be exported correct, because NULL will be transformed into '0'. This will deactivate all variants with the next import. (https://issues.shopware.com/issues/NEXT-21461)

Maybe it would be little cleaner to return NULL for all NULL-Values?