### PR TITLE
Fix Export Generation for "product comparison" Sales Channels

### DIFF
--- a/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -65,7 +65,6 @@ class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
     {
         $criteria = new Criteria();
         $criteria
-            ->addFilter(new EqualsFilter('typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT))
             ->addFilter(new EqualsFilter('active', true));
 
         $salesChannelIds = $this->salesChannelRepository->searchIds($criteria, Context::createDefaultContext());


### PR DESCRIPTION
Removed the Type Check for the Sales Channel.
This way Storefront Sales Channels and Product Comparison will have their Product Export generated. Load should increase marginally as all Sales Channel Ids that are active will be returned. Runtime should be impacted marginally as each active Sales Channel will be checked until line 92.