### PR TITLE
Check for EntityTranslationDefinition in ApiController Write Method

### DIFF
--- a/Framework/Api/Controller/ApiController.php
+++ b/Framework/Api/Controller/ApiController.php
@@ -780,7 +780,7 @@ class ApiController extends AbstractController
             $eventIds = $event->getIds();
             $entityId = array_pop($eventIds);
 
-            if ($definition instanceof MappingEntityDefinition) {
+            if ($definition instanceof MappingEntityDefinition || $definition instanceof EntityTranslationDefinition) {
                 return new Response(null, Response::HTTP_NO_CONTENT);
             }
 


### PR DESCRIPTION
Add Check for EntityTranslationDefinition if the lenght of pathSegments is zero, because when a Translation is directly written out of the Backend, the Request would result in an Error. The "$entityId" would be an Array, instead of a String in this Scenario