### PR TITLE
Fix check for existence of export directory in ProductExportFileHandler

### DIFF
--- a/Content/ProductExport/Service/ProductExportFileHandler.php
+++ b/Content/ProductExport/Service/ProductExportFileHandler.php
@@ -100,7 +100,7 @@ class ProductExportFileHandler implements ProductExportFileHandlerInterface
 
     private function ensureDirectoryExists(): void
     {
-        if (!$this->fileSystem->fileExists($this->exportDirectory)) {
+        if (!$this->fileSystem->directoryExists($this->exportDirectory)) {
             $this->fileSystem->createDirectory($this->exportDirectory);
         }
     }


### PR DESCRIPTION
1. Why is this change necessary?

For using the Google Bucket adapte and product export 

2. What does this change do, exactly?

Fixes the problem with exceeded rate limit for object mutation operations on bucket directory object

3. Describe each step to reproduce the issue or behaviour.

Config filesystem private to use Google Bucket adapter
Have multiple consumer pods that are consuming message queue
Go to Admin Import/Export -> Select Export tab -> Select a profile then run Export

4. Please link to the relevant issues (if any).

[#3357](https://github.com/shopware/shopware/issues/3357)