### PR TITLE
Added phpstan class-string hint to validate FkField definitions

### DIFF
--- a/Framework/DataAbstractionLayer/Field/FkField.php
+++ b/Framework/DataAbstractionLayer/Field/FkField.php
@@ -36,6 +36,9 @@ class FkField extends Field implements StorageAware
 
     private ?string $referenceEntity = null;
 
+    /**
+     * @param class-string<\Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition> $referenceClass
+     */
     public function __construct(
         string $storageName,
         string $propertyName,


### PR DESCRIPTION
This PR helps PHPStan reject FkField definitions that don’t point to a valid EntityDefinition-derived class. Because I managed to point these fields to entities instead of definitions at least three times now, d’oh.