### PR TITLE
NEXT-39835: Fix Cyprus VAT Validation

### DIFF
--- a/Migration/V6_6/Migration1732821058UpdateCyprusVatValidationFormat.php
+++ b/Migration/V6_6/Migration1732821058UpdateCyprusVatValidationFormat.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1732821058UpdateCyprusVatValidationFormat extends MigrationStep
+{
+    private const VAT_PATTERNS = [
+        'CY' => 'CY\d{8}[A-Z]'
+    ];
+
+    public function getCreationTimestamp(): int
+    {
+        return 1732821058;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $update = new RetryableQuery(
+            $connection,
+            $connection->prepare('UPDATE country SET vat_id_pattern = :pattern WHERE iso = :iso')
+        );
+
+        foreach (self::VAT_PATTERNS as $key => $pattern) {
+            $update->execute([
+                'pattern' => $pattern,
+                'iso' => $key,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
1. Why is this change necessary?
Cyprus VAT validation format is wrong

3. What does this change do, exactly?
Fix Cyprus VAT validation format

5. Describe each step to reproduce the issue or behaviour.
https://github.com/shopware/shopware/issues/5716

7. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/5716