### PR TITLE
Friendly message during Platform.sh build in ActiveAppsLoader

### DIFF
--- a/Framework/App/ActiveAppsLoader.php
+++ b/Framework/App/ActiveAppsLoader.php
@@ -67,7 +67,14 @@ class ActiveAppsLoader implements ResetInterface
             ], $data);
         } catch (\Throwable $e) {
             if (\defined('\STDERR') && !EnvironmentHelper::getVariable('TESTS_RUNNING')) {
-                fwrite(\STDERR, 'Warning: Failed to load apps. Loading apps from local. Message: ' . $e->getMessage() . \PHP_EOL);
+                $isPlatform = (bool) getenv('PLATFORM_PROJECT') || (bool) getenv('PLATFORM_APPLICATION');
+                $isBuildPhase = (getenv('PLATFORM_APPLICATION_NAME') && !getenv('PLATFORM_ENVIRONMENT') && !getenv('PLATFORM_RELATIONSHIPS'));
+
+                if ($isPlatform && $isBuildPhase) {
+                    fwrite(\STDERR, 'Apps not loaded from DB during Platform.sh build (DB services are unavailable by design). Falling back to local app assets.' . \PHP_EOL);
+                } else {
+                    fwrite(\STDERR, 'Warning: Failed to load apps. Loading apps from local. Message: ' . $e->getMessage() . \PHP_EOL);
+                }
             }
 
             return array_map(fn (Manifest $manifest) => [


### PR DESCRIPTION
During Platform.sh build phase, services are not available.
Currently an error message is shown:
```
W: Warning: Failed to load apps. Loading apps from local. Message: An exception occurred in the driver: SQLSTATE[HY000] [2002] No such file or directory
```
It could be worrying for a PaaS customer.

This PR intends to show a nicer message:
```
Apps not loaded from DB during Platform.sh build (DB services are unavailable by design). Falling back to local app assets.
```